### PR TITLE
feat: Use ViT for images and enable model caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,120 @@
-# embeddings-service
+# Embeddings Service
+
+This service provides an API for generating text and image embeddings using pre-trained models. It is built with FastAPI and designed to be run with Docker.
+
+## Features
+
+-   **Text Embeddings**: Utilizes Sentence Transformers (default model: `all-MiniLM-L6-v2`) to generate embeddings for text strings.
+-   **Image Embeddings**: Employs Hugging Face Transformers (default model: `google/vit-base-patch16-224`) to generate embeddings for images (provided as URLs or byte content).
+-   **API Key Authentication**: Protects endpoints with API key authentication.
+-   **Model Caching**: Downloads and caches models locally to improve startup times and reduce reliance on internet connectivity after the initial download.
+-   **Dockerized**: Easy to deploy and run using Docker and Docker Compose.
+
+## Prerequisites
+
+-   Docker
+-   Docker Compose
+
+## Setup and Running
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url>
+    cd <directory_name_after_clone_typically_embeddings-service> 
+    ```
+    (Replace `<repository_url>` and `<directory_name_after_clone_typically_embeddings-service>` accordingly)
+
+2.  **Environment Variables:**
+    Create a `.env` file by copying `example.env`:
+    ```bash
+    cp example.env .env
+    ```
+    Edit `.env` to set your desired `VALID_API_KEYS` (comma-separated if multiple).
+
+3.  **Build and Run with Docker Compose:**
+    ```bash
+    docker-compose up --build
+    ```
+    The service will be available at `http://localhost:8000`. The API documentation (Swagger UI) can be accessed at `http://localhost:8000/docs`.
+
+## API Endpoints
+
+-   `POST /v1/embeddings/text`: Generates text embeddings.
+    -   **Request Body**:
+        ```json
+        {
+          "input": "Your text string here"
+        }
+        ```
+    -   **Headers**: `X-API-Key: <your_api_key>`
+-   `POST /v1/embeddings/image`: Generates image embeddings.
+    -   **Request Body**:
+        ```json
+        {
+          "input": "url_or_bytes_representing_image"
+        }
+        ```
+        (Input can be a publicly accessible image URL. For binary image data, ensure your client sends it appropriately, e.g., as part of a multipart/form-data request if the endpoint is adapted for it, or as raw bytes if the client and server are set up for that. The current server implementation expects URL or raw bytes directly if feasible by the HTTP client library used to call it.)
+    -   **Headers**: `X-API-Key: <your_api_key>`
+-   `GET /v1/models`: Lists available models (name, type, dimension, description).
+-   `GET /health`: Health check endpoint.
+
+## Model Caching
+
+To enhance performance and reduce redundant downloads, the service implements model caching:
+
+-   **How it works**: When a model is first requested (either text or image), it is downloaded from its source (e.g., Hugging Face Hub for `transformers` models, or Sentence Transformers community models) and stored locally. Subsequent requests for the same model will load it from the local cache.
+-   **Benefits**:
+    -   Significantly speeds up application startup and first request times after the initial download.
+    -   Allows operation even without an internet connection once models are cached.
+-   **Default Cache Location**: Models are cached by default in the `./model_cache` directory within the application's root directory (i.e., `/app/model_cache` inside the Docker container).
+-   **Persistence**: The `docker-compose.yml` file is configured to mount this `./model_cache` directory from your host machine into the container (`./model_cache:/app/model_cache`). This ensures that your downloaded models persist even if you stop and restart the Docker container, saving you from re-downloading them.
+
+## Dependencies
+
+The service relies on several Python libraries, including:
+
+-   `fastapi`: For building the API.
+-   `uvicorn`: As the ASGI server.
+-   `pydantic`: For data validation.
+-   `python-dotenv`: For managing environment variables.
+-   `sentence-transformers`: For text embeddings (e.g., `all-MiniLM-L6-v2`).
+-   `transformers`: From Hugging Face, for image embeddings (e.g., `google/vit-base-patch16-224`).
+-   `torch`: Core deep learning library.
+-   `Pillow`: For image processing.
+-   `requests`: For fetching images from URLs.
+-   `python-multipart`: For handling file uploads (though not explicitly used by default image embedding endpoint for direct file upload, good to have for FastAPI).
+
+These are managed via `requirements.txt`.
+
+## Testing
+
+Unit tests are located in the `tests/` directory and can be run using:
+
+```bash
+python -m unittest discover tests
+```
+(Ensure you have the necessary dependencies installed in your environment if running tests outside of Docker, e.g., by creating a virtual environment and running `pip install -r requirements.txt`).
+
+## Project Structure
+
+```
+.
+├── app/                  # Main application code
+│   ├── api/              # API endpoint definitions (routers)
+│   │   └── v1/           # API version 1
+│   ├── models/           # Embedding model logic (base, image, text)
+│   └── core/             # Configuration, security, etc.
+├── tests/                # Unit tests
+├── .env                  # Local environment variables (gitignored)
+├── example.env           # Example environment variables file
+├── Dockerfile            # Instructions for building the Docker image
+├── docker-compose.yml    # Docker Compose configuration for local development
+├── main.py               # FastAPI application entry point
+├── README.md             # This file
+└── requirements.txt      # Python package dependencies
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a pull request or open an issue for any bugs, feature requests, or improvements.

--- a/app/models/base_embedder.py
+++ b/app/models/base_embedder.py
@@ -1,13 +1,23 @@
+import os
 from abc import ABC, abstractmethod
 from typing import Any, List
 
 class BaseEmbedder(ABC):
     """Абстрактный базовый класс для всех моделей эмбеддингов."""
 
-    def __init__(self, model_name: str, model_type: str):
+    def __init__(self, model_name: str, model_type: str, model_cache_dir: str = "./model_cache"):
         self.model_name = model_name
         self.model_type = model_type # "text" или "image"
+        self.model_cache_dir = model_cache_dir
         self.model = None
+
+        if self.model_cache_dir:
+            os.makedirs(self.model_cache_dir, exist_ok=True)
+            print(f"Models will be cached in: {os.path.abspath(self.model_cache_dir)}")
+        else:
+            print("Model cache directory not specified. Models will be downloaded to default Hugging Face cache.")
+
+
         self._load_model() # Загрузка модели при инициализации
 
     @abstractmethod

--- a/app/models/image_embedder.py
+++ b/app/models/image_embedder.py
@@ -1,5 +1,5 @@
 import torch
-import clip
+from transformers import AutoModel, AutoImageProcessor
 from PIL import Image
 from io import BytesIO
 import requests
@@ -7,40 +7,49 @@ from typing import List, Union
 from .base_embedder import BaseEmbedder
 
 class ImageEmbedder(BaseEmbedder):
-    """Класс для эмбеддингов изображений с использованием CLIP."""
-    description = "CLIP model for image embeddings."
+    """Класс для эмбеддингов изображений с использованием Hugging Face Transformers."""
+    description = "Hugging Face ViT model for image embeddings."
 
-    def __init__(self, model_name: str = "ViT-B/32"): # Один из стандартных CLIP
+    def __init__(self, model_name: str = "google/vit-base-patch16-224", model_cache_dir: str = "./model_cache"):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        super().__init__(model_name=model_name, model_type="image")
+        super().__init__(model_name=model_name, model_type="image", model_cache_dir=model_cache_dir)
         self._dimension = 0 # Будет установлено после загрузки модели
-
+        self.processor = None # Инициализируем процессор
 
     def _load_model(self):
-        print(f"Loading image model: {self.model_name} on device: {self.device}...")
+        print(f"Loading image model: {self.model_name} on device: {self.device} from cache: {self.model_cache_dir}...")
         try:
-            self.model, self.preprocess = clip.load(self.model_name, device=self.device)
-            # Получаем размерность после загрузки
-            # Для CLIP стандартный способ узнать размерность эмбеддинга изображения:
-            # model.visual.output_dim или через тестовый прогон
-            if hasattr(self.model.visual, 'output_dim'):
-                 self._dimension = self.model.visual.output_dim
-            else: # Fallback if output_dim is not directly available
-                dummy_image = Image.new('RGB', (224, 224)) # CLIP typically uses 224x224
-                image_input = self.preprocess(dummy_image).unsqueeze(0).to(self.device)
+            self.processor = AutoImageProcessor.from_pretrained(self.model_name, cache_dir=self.model_cache_dir)
+            self.model = AutoModel.from_pretrained(self.model_name, cache_dir=self.model_cache_dir).to(self.device)
+            
+            # Получаем размерность после загрузки модели
+            # Обычно это можно найти в конфигурации модели
+            if hasattr(self.model.config, 'hidden_size'):
+                self._dimension = self.model.config.hidden_size
+            else:
+                # Fallback: если hidden_size нет, можно попробовать тестовый прогон
+                # Однако, для ViT моделей hidden_size обычно есть.
+                # Этот fallback может потребовать адаптации под конкретный вывод модели ViT
+                dummy_image = Image.new('RGB', (self.processor.size['height'], self.processor.size['width']))
+                inputs = self.processor(images=dummy_image, return_tensors="pt").to(self.device)
                 with torch.no_grad():
-                    dummy_embedding = self.model.encode_image(image_input)
-                self._dimension = dummy_embedding.shape[1]
+                    outputs = self.model(**inputs)
+                    # Для ViT, часто интересует эмбеддинг CLS токена или усредненный пул
+                    # last_hidden_state имеет размер (batch_size, sequence_length, hidden_size)
+                    # CLS токен обычно первый: outputs.last_hidden_state[:, 0, :]
+                    # Здесь мы просто проверяем последнюю размерность
+                    dummy_embedding = outputs.last_hidden_state
+                self._dimension = dummy_embedding.shape[-1] # Берем последнюю размерность
 
             print(f"Image model {self.model_name} loaded. Dimension: {self._dimension}")
         except Exception as e:
-            print(f"Error loading CLIP model {self.model_name}: {e}")
+            print(f"Error loading Hugging Face model {self.model_name}: {e}")
             self.model = None
-            self.preprocess = None
+            self.processor = None
             raise
 
     def get_embedding(self, image_source: Union[bytes, str]) -> List[float]:
-        if self.model is None or self.preprocess is None:
+        if self.model is None or self.processor is None:
             raise RuntimeError(f"Image model {self.model_name} is not loaded properly.")
 
         image_bytes: bytes
@@ -61,19 +70,31 @@ class ImageEmbedder(BaseEmbedder):
         except Exception as e:
             raise ValueError(f"Could not open image. Error: {e}")
 
-        image_input = self.preprocess(image).unsqueeze(0).to(self.device)
+        inputs = self.processor(images=image, return_tensors="pt").to(self.device)
+        
         with torch.no_grad():
-            embedding = self.model.encode_image(image_input)
+            outputs = self.model(**inputs)
+        
+        # last_hidden_state имеет размер (batch_size, sequence_length, hidden_size)
+        # Для ViT, часто берут эмбеддинг CLS токена (первый токен) или усредняют все токены.
+        # Усреднение по последовательности токенов (dim=1)
+        embedding = outputs.last_hidden_state.mean(dim=1)
 
         return embedding.cpu().numpy().squeeze().tolist()
 
     @property
     def dimension(self) -> int:
-        if self.model is None:
-            raise RuntimeError(f"Image model {self.model_name} is not loaded, dimension unknown.")
+        if self._dimension == 0 and self.model is not None: # Если модель загружена, но размерность не установлена
+             # Попытка получить размерность из конфигурации загруженной модели
+            if hasattr(self.model.config, 'hidden_size'):
+                self._dimension = self.model.config.hidden_size
+            else: # Если не удалось, вызываем ошибку, т.к. модель должна быть загружена для определения
+                 raise RuntimeError(f"Image model {self.model_name} is loaded, but dimension could not be determined from config.")
+        elif self.model is None and self._dimension == 0:
+             raise RuntimeError(f"Image model {self.model_name} is not loaded, dimension unknown.")
         return self._dimension
 
-# Пример добавления другой модели CLIP (если понадобится)
+# Пример НЕ УДАЛЯТЬ, может пригодиться для других моделей
 # class AnotherImageEmbedder(ImageEmbedder):
-#     def __init__(self, model_name: str = "ViT-L/14"):
-#         super().__init__(model_name=model_name)
+#     def __init__(self, model_name: str = "facebook/deit-base-distilled-patch16-224", model_cache_dir: str = "./model_cache"): # Пример другой модели
+#         super().__init__(model_name=model_name, model_cache_dir=model_cache_dir)

--- a/app/models/text_embedder.py
+++ b/app/models/text_embedder.py
@@ -6,14 +6,14 @@ class TextEmbedder(BaseEmbedder):
     """Класс для эмбеддингов текста с использованием SentenceTransformer."""
     description = "Sentence Transformer model for text embeddings."
 
-    def __init__(self, model_name: str = "all-MiniLM-L6-v2"):
-        super().__init__(model_name=model_name, model_type="text")
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2", model_cache_dir: str = "./model_cache"):
+        super().__init__(model_name=model_name, model_type="text", model_cache_dir=model_cache_dir)
         self._dimension = 0 # Будет установлено после загрузки модели
 
     def _load_model(self):
-        print(f"Loading text model: {self.model_name}...")
+        print(f"Loading text model: {self.model_name} from cache: {self.model_cache_dir}...")
         try:
-            self.model = SentenceTransformer(self.model_name)
+            self.model = SentenceTransformer(self.model_name, cache_folder=self.model_cache_dir)
             # Получаем размерность после загрузки
             dummy_embedding = self.model.encode("test")
             self._dimension = dummy_embedding.shape[0]
@@ -39,5 +39,5 @@ class TextEmbedder(BaseEmbedder):
 
 # Пример добавления другой текстовой модели (если понадобится)
 # class AnotherTextEmbedder(TextEmbedder):
-#     def __init__(self, model_name: str = "paraphrase-multilingual-MiniLM-L12-v2"):
-#         super().__init__(model_name=model_name)
+#     def __init__(self, model_name: str = "paraphrase-multilingual-MiniLM-L12-v2", model_cache_dir: str = "./model_cache"):
+#         super().__init__(model_name=model_name, model_cache_dir=model_cache_dir)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./app:/app/app # Mounts the app code
+      - ./main.py:/app/main.py # Mounts the main.py file
+      - ./.env:/app/.env # Mounts the .env file
+      - ./model_cache:/app/model_cache # Persists downloaded models
+    # Optional: Environment variable to configure model cache directory if needed in the future
+    # environment:
+    #   MODEL_CACHE_DIR: /app/model_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ python-dotenv
 sentence-transformers
 torch
 torchvision
-# torchaudio # Может понадобиться для некоторых конфигураций torch/CLIP
-openai-clip
+transformers
 Pillow
-python-multipart # Для загрузки файлов
-requests # Для загрузки изображений по URL (если нужно)
+python-multipart
+requests

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the tests directory a Python package.

--- a/tests/test_image_embedder.py
+++ b/tests/test_image_embedder.py
@@ -1,0 +1,94 @@
+import unittest
+import os
+import sys
+import shutil
+from PIL import Image
+from io import BytesIO
+
+# Add project root to sys.path to allow importing app modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.models.image_embedder import ImageEmbedder
+
+class TestImageEmbedder(unittest.TestCase):
+    DEFAULT_MODEL_NAME = "google/vit-base-patch16-224"
+    EXPECTED_DIMENSION = 768
+    CACHE_DIR = "./test_cache/image_models_cache"
+
+    def setUp(self):
+        # Ensure cache directory exists and is empty before each test that uses it
+        if os.path.exists(self.CACHE_DIR):
+            shutil.rmtree(self.CACHE_DIR)
+        os.makedirs(self.CACHE_DIR, exist_ok=True)
+
+    def tearDown(self):
+        # Clean up cache directory after tests
+        if os.path.exists(self.CACHE_DIR):
+            shutil.rmtree(self.CACHE_DIR)
+
+    def test_image_model_loading(self):
+        print(f"Current working directory: {os.getcwd()}")
+        # Test with default model name, specify cache to avoid polluting default HF cache
+        embedder = ImageEmbedder(model_name=self.DEFAULT_MODEL_NAME, model_cache_dir=self.CACHE_DIR)
+        self.assertIsNotNone(embedder.model, "Model should be loaded.")
+        self.assertIsNotNone(embedder.processor, "Processor should be loaded.")
+        self.assertEqual(embedder.dimension, self.EXPECTED_DIMENSION,
+                         f"Dimension should be {self.EXPECTED_DIMENSION} for {self.DEFAULT_MODEL_NAME}")
+
+    def test_image_embedding_generation(self):
+        # Test with default model name, specify cache
+        embedder = ImageEmbedder(model_name=self.DEFAULT_MODEL_NAME, model_cache_dir=self.CACHE_DIR)
+        
+        # Create a dummy image
+        dummy_pil_image = Image.new('RGB', (224, 224), color = 'red')
+        
+        # Convert to bytes
+        img_byte_arr = BytesIO()
+        dummy_pil_image.save(img_byte_arr, format='PNG')
+        image_bytes = img_byte_arr.getvalue()
+        
+        embedding = embedder.get_embedding(image_bytes)
+        
+        self.assertIsInstance(embedding, list, "Embedding should be a list.")
+        self.assertTrue(all(isinstance(x, float) for x in embedding), "All elements in embedding should be floats.")
+        self.assertEqual(len(embedding), self.EXPECTED_DIMENSION,
+                         f"Embedding length should be equal to dimension {self.EXPECTED_DIMENSION}.")
+
+    def test_model_caching_for_image_embedder(self):
+        # Instantiate embedder, which should download and cache the model
+        ImageEmbedder(model_name=self.DEFAULT_MODEL_NAME, model_cache_dir=self.CACHE_DIR)
+        
+        # Check if the cache directory is no longer empty or contains expected model files/folders
+        # Hugging Face model cache structure can be complex (e.g. refs, blobs, snapshots).
+        # A common pattern is a 'snapshots' directory containing subdirectories for models.
+        # We'll check for non-emptiness and a 'snapshots' dir as a proxy.
+        
+        self.assertTrue(os.path.exists(self.CACHE_DIR), "Cache directory should exist.")
+        self.assertTrue(len(os.listdir(self.CACHE_DIR)) > 0, "Cache directory should not be empty after model load.")
+        
+        # More specific check: Hugging Face often creates a 'snapshots' folder
+        # and then a subfolder with the model's commit hash.
+        # For "google/vit-base-patch16-224", there isn't one specific file, but a directory.
+        # Let's check for *any* subdirectory within snapshots, as hash names are unpredictable.
+        snapshots_path = os.path.join(self.CACHE_DIR, "models--" + self.DEFAULT_MODEL_NAME.replace("/", "--"))
+        # Alternative check for general Hugging Face structure
+        # Check for any files in common locations like 'blobs' or 'snapshots'
+        # This test assumes that *some* files will be downloaded directly into CACHE_DIR or subdirs like 'snapshots'
+        # or a directory named like 'models--google--vit-base-patch16-224'.
+        
+        # A simple check that *something* related to the model is in the cache dir.
+        # The exact structure can vary based on transformers version.
+        # We look for a directory that starts with 'models--' followed by the model name.
+        expected_model_dir_prefix = "models--" + self.DEFAULT_MODEL_NAME.replace("/", "--")
+        found_model_dir = False
+        for item in os.listdir(self.CACHE_DIR):
+            if item.startswith(expected_model_dir_prefix):
+                found_model_dir = True
+                model_files_path = os.path.join(self.CACHE_DIR, item)
+                self.assertTrue(len(os.listdir(model_files_path)) > 0, f"Model specific directory '{item}' should not be empty.")
+                break
+        self.assertTrue(found_model_dir, f"Cache directory should contain a folder starting with '{expected_model_dir_prefix}'.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_text_embedder.py
+++ b/tests/test_text_embedder.py
@@ -1,0 +1,75 @@
+import unittest
+import os
+import sys
+import shutil
+
+# Add project root to sys.path to allow importing app modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.models.text_embedder import TextEmbedder
+
+class TestTextEmbedder(unittest.TestCase):
+    DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2" # Default model for TextEmbedder
+    # The dimension for all-MiniLM-L6-v2 is 384.
+    # We can fetch this dynamically or hardcode if we are sure about the default model.
+    # For this test, we'll check if it's a positive integer,
+    # as the main goal is testing loading and caching.
+    EXPECTED_DIMENSION_TEXT = 384 
+    CACHE_DIR = "./test_cache/text_models_cache"
+
+    def setUp(self):
+        # Ensure cache directory exists and is empty before each test that uses it
+        if os.path.exists(self.CACHE_DIR):
+            shutil.rmtree(self.CACHE_DIR)
+        os.makedirs(self.CACHE_DIR, exist_ok=True)
+
+    def tearDown(self):
+        # Clean up cache directory after tests
+        if os.path.exists(self.CACHE_DIR):
+            shutil.rmtree(self.CACHE_DIR)
+
+    def test_text_model_loading(self):
+        # Test with default model name, specify cache
+        embedder = TextEmbedder(model_name=self.DEFAULT_MODEL_NAME, model_cache_dir=self.CACHE_DIR)
+        self.assertIsNotNone(embedder.model, "Text model should be loaded.")
+        self.assertEqual(embedder.dimension, self.EXPECTED_DIMENSION_TEXT,
+                         f"Dimension should be {self.EXPECTED_DIMENSION_TEXT} for {self.DEFAULT_MODEL_NAME}")
+        self.assertTrue(embedder.dimension > 0, "Text model dimension should be a positive integer.")
+
+    def test_model_caching_for_text_embedder(self):
+        # Instantiate embedder, which should download and cache the model
+        TextEmbedder(model_name=self.DEFAULT_MODEL_NAME, model_cache_dir=self.CACHE_DIR)
+        
+        # Check if the cache directory contains the model files.
+        # Sentence-transformers typically creates a folder with the model name directly
+        # (or a slightly modified version, e.g., replacing '/' with '_').
+        # For "all-MiniLM-L6-v2", it should create a folder like "sentence-transformers_all-MiniLM-L6-v2".
+        
+        self.assertTrue(os.path.exists(self.CACHE_DIR), "Cache directory should exist.")
+        self.assertTrue(len(os.listdir(self.CACHE_DIR)) > 0, "Cache directory should not be empty after model load.")
+        
+        # Construct the expected model directory name based on SentenceTransformer's convention.
+        # It often prepends 'sentence-transformers_' and replaces slashes.
+        # However, for "all-MiniLM-L6-v2", it might just be the model name or a slight variation.
+        # A common pattern is 'user_model-name' or 'model-name' if no user.
+        # Let's check for a directory that contains the model name.
+        
+        expected_model_path_segment = self.DEFAULT_MODEL_NAME.replace("/", "_") # e.g., "all-MiniLM-L6-v2"
+        model_found_in_cache = False
+        for item in os.listdir(self.CACHE_DIR):
+            # Sentence-transformers sometimes creates subdirs like:
+            # 'sentence-transformers_all-MiniLM-L6-v2' or just 'all-MiniLM-L6-v2'
+            # We will check if a directory corresponding to the model name exists
+            # and contains files.
+            if expected_model_path_segment in item and os.path.isdir(os.path.join(self.CACHE_DIR, item)):
+                model_specific_dir = os.path.join(self.CACHE_DIR, item)
+                self.assertTrue(len(os.listdir(model_specific_dir)) > 0,
+                                f"Model directory '{item}' in cache should not be empty.")
+                model_found_in_cache = True
+                break
+        
+        self.assertTrue(model_found_in_cache, 
+                        f"Cache directory should contain a folder related to '{expected_model_path_segment}'.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Replaced CLIP image embedding model with `google/vit-base-patch16-224` from Hugging Face Transformers.
- Implemented model caching for both image and text models to a local directory (`./model_cache` by default). This speeds up subsequent initializations and reduces reliance on internet connectivity after the first download.
- Updated `requirements.txt` to include `transformers` and remove `openai-clip`.
- Configured `docker-compose.yml` to persist the `./model_cache` directory using a volume.
- Added unit tests for the new image model, including embedding generation and model caching functionality for both image and text embedders.
- Updated `README.md` to reflect these changes, including the new model, caching behavior, and setup instructions.